### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/core/api_client.py
+++ b/src/evo_client/core/api_client.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
-from typing import Literal, Optional, Dict, Any, Union, List, Type, overload, Iterable
+
 import logging
 from multiprocessing.pool import AsyncResult
-from typing import Any
-from typing import TypeVar
-from .request_handler import RequestHandler
-from .configuration import Configuration
-from ..exceptions.api_exceptions import ApiClientError
-from multiprocessing.pool import AsyncResult
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
+
 from pydantic import BaseModel
-import logging
-from multiprocessing.pool import AsyncResult
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, overload
 
 from ..exceptions.api_exceptions import ApiClientError
 from .configuration import Configuration
@@ -79,8 +83,8 @@ class ApiClient:
         _return_http_data_only: bool = True,
         _preload_content: bool = True,
         _request_timeout: Optional[Union[float, tuple]] = None,
-    ) -> Union[Any, AsyncResult[Any]]: ...
-
+    ) -> Union[Any, AsyncResult[Any]]:
+        ...
 
     @overload
     def call_api(
@@ -99,8 +103,8 @@ class ApiClient:
         _return_http_data_only: bool = True,
         _preload_content: bool = True,
         _request_timeout: Optional[Union[float, tuple]] = None,
-    ) -> Union[T, AsyncResult[T]]: ...
-
+    ) -> Union[T, AsyncResult[T]]:
+        ...
 
     @overload
     def call_api(
@@ -119,7 +123,8 @@ class ApiClient:
         _return_http_data_only: bool = True,
         _preload_content: bool = True,
         _request_timeout: Optional[Union[float, tuple]] = None,
-    ) -> Union[List[T], AsyncResult[List[T]]]: ...
+    ) -> Union[List[T], AsyncResult[List[T]]]:
+        ...
 
     @overload
     def call_api(
@@ -138,7 +143,8 @@ class ApiClient:
         _return_http_data_only: bool = True,
         _preload_content: bool = True,
         _request_timeout: Optional[Union[float, tuple]] = None,
-    ) -> Union[AsyncResult[T], AsyncResult[List[T]], AsyncResult[Any]]: ...
+    ) -> Union[AsyncResult[T], AsyncResult[List[T]], AsyncResult[Any]]:
+        ...
 
     @overload
     def call_api(
@@ -157,7 +163,8 @@ class ApiClient:
         _return_http_data_only: bool = True,
         _preload_content: bool = True,
         _request_timeout: Optional[Union[float, tuple]] = None,
-    ) -> Union[T, List[T], Any]: ...
+    ) -> Union[T, List[T], Any]:
+        ...
 
     def call_api(
         self,
@@ -211,4 +218,3 @@ class ApiClient:
             _preload_content=_preload_content,
             _request_timeout=_request_timeout,
         )
-

--- a/src/evo_client/core/request_handler.py
+++ b/src/evo_client/core/request_handler.py
@@ -1,15 +1,10 @@
-
-from typing import Any, Dict, Optional
-from multiprocessing.pool import ThreadPool, AsyncResult
-from typing import Any, Type, Union, TypeVar, Iterable, List, overload
 import logging
 from multiprocessing.pool import AsyncResult, ThreadPool
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, List, Optional, Type, TypeVar, Union, overload
 
-from ..exceptions.api_exceptions import RequestError
-from .configuration import Configuration
-from .response import RESTResponse
 from pydantic import BaseModel
+
+from .configuration import Configuration
 from .rest import RESTClient
 
 logger = logging.getLogger(__name__)
@@ -30,12 +25,16 @@ class RequestHandler:
         self.pool.join()
 
     @overload
-    def execute(self, response_type: None, **kwargs) -> Any: ...
-    @overload
-    def execute(self, response_type: Type[T], **kwargs) -> T: ...
+    def execute(self, response_type: None, **kwargs) -> Any:
+        ...
 
     @overload
-    def execute(self, response_type: Type[Iterable[T]], **kwargs) -> List[T]: ...
+    def execute(self, response_type: Type[T], **kwargs) -> T:
+        ...
+
+    @overload
+    def execute(self, response_type: Type[Iterable[T]], **kwargs) -> List[T]:
+        ...
 
     def execute(
         self, response_type: Optional[Type[T] | Type[Iterable[T]]] = None, **kwargs
@@ -44,15 +43,18 @@ class RequestHandler:
         return self._make_request(response_type, **kwargs)
 
     @overload
-    def execute_async(self, response_type: None, **kwargs) -> AsyncResult[Any]: ...
+    def execute_async(self, response_type: None, **kwargs) -> AsyncResult[Any]:
+        ...
 
     @overload
-    def execute_async(self, response_type: Type[T], **kwargs) -> AsyncResult[T]: ...
+    def execute_async(self, response_type: Type[T], **kwargs) -> AsyncResult[T]:
+        ...
 
     @overload
     def execute_async(
         self, response_type: Type[Iterable[T]], **kwargs
-    ) -> AsyncResult[List[T]]: ...
+    ) -> AsyncResult[List[T]]:
+        ...
 
     def execute_async(
         self, response_type: Optional[Type[T] | Type[Iterable[T]]] = None, **kwargs

--- a/src/evo_client/core/response.py
+++ b/src/evo_client/core/response.py
@@ -1,10 +1,20 @@
-
-from typing import Optional, Dict, Any, TypeVar, Type, Iterable
 import io
 import json
-from urllib3.response import HTTPResponse, BaseHTTPResponse
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    get_args,
+    get_origin,
+    overload,
+)
+
 from pydantic import BaseModel
-from typing import get_origin, get_args, List, overload
+from urllib3.response import BaseHTTPResponse
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -34,10 +44,12 @@ class RESTResponse(io.IOBase):
         raise ValueError("Response content is not in JSON format")
 
     @overload
-    def deserialize(self, response_type: Type[T]) -> T: ...
+    def deserialize(self, response_type: Type[T]) -> T:
+        ...
 
     @overload
-    def deserialize(self, response_type: Type[Iterable[T]]) -> List[T]: ...
+    def deserialize(self, response_type: Type[Iterable[T]]) -> List[T]:
+        ...
 
     def deserialize(self, response_type: Type[T] | Type[Iterable[T]]) -> T | List[T]:
         """Deserialize response data into the specified type."""

--- a/src/evo_client/core/rest.py
+++ b/src/evo_client/core/rest.py
@@ -1,18 +1,15 @@
-
-from typing import Optional, Dict, Any, Union, Type, TypeVar
-
 import json
 import logging
 import ssl
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, TypeVar, Union
 from urllib.parse import urlencode
 
 import certifi
 import urllib3
+from pydantic import BaseModel
 from urllib3.response import BaseHTTPResponse
 
 from ..core.configuration import Configuration
-from pydantic import BaseModel
 from ..exceptions.api_exceptions import ApiException
 from .response import RESTResponse
 

--- a/test/core/test_api_client.py
+++ b/test/core/test_api_client.py
@@ -3,7 +3,6 @@
 from unittest.mock import Mock, patch
 
 import pytest
-from unittest.mock import patch, Mock, PropertyMock
 
 from evo_client.core.api_client import ApiClient
 from evo_client.core.configuration import Configuration


### PR DESCRIPTION
There appear to be some python formatting errors in 8d66394794ab6ee905c2f4fb07d0833e08f6ef4c. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.