### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/test/core/test_response.py
+++ b/test/core/test_response.py
@@ -1,9 +1,11 @@
-from unittest.mock import Mock
-import pytest
-from evo_client.core.response import RESTResponse
-from urllib3.response import BaseHTTPResponse
-from pydantic import BaseModel
 from typing import List
+from unittest.mock import Mock
+
+import pytest
+from pydantic import BaseModel
+from urllib3.response import BaseHTTPResponse
+
+from evo_client.core.response import RESTResponse
 
 
 class SomeBaseModel(BaseModel):


### PR DESCRIPTION
There appear to be some python formatting errors in df5e9ba5a22aba179b58fd0a96ee2d1f373cf87d. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.