### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/test/core/test_request_handler.py
+++ b/test/core/test_request_handler.py
@@ -1,12 +1,12 @@
 from unittest.mock import Mock
+
 import pytest
-from evo_client.core.request_handler import RequestHandler
-from evo_client.core.configuration import Configuration
-from evo_client.core.response import RESTResponse
-from urllib3.response import BaseHTTPResponse
 from pydantic import BaseModel
-from typing import List
-import multiprocessing.pool
+from urllib3.response import BaseHTTPResponse
+
+from evo_client.core.configuration import Configuration
+from evo_client.core.request_handler import RequestHandler
+from evo_client.core.response import RESTResponse
 
 
 class TestModel(BaseModel):

--- a/test/core/test_rest.py
+++ b/test/core/test_rest.py
@@ -7,8 +7,6 @@ import pytest
 import urllib3
 from urllib3 import Timeout, exceptions
 
-import json
-
 from evo_client.core.configuration import Configuration
 from evo_client.core.response import RESTResponse
 from evo_client.core.rest import RESTClient


### PR DESCRIPTION
There appear to be some python formatting errors in 579741da62873a02c80ba2a10557e86ba319769a. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.