### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/core/configuration.py
+++ b/src/evo_client/core/configuration.py
@@ -4,16 +4,15 @@ Handles authentication, logging, and connection settings for API requests.
 """
 
 from __future__ import annotations
-import copy
+
 import logging
 import multiprocessing
 import sys
-import urllib3
-from typing import Dict, Optional, Callable, ClassVar
-from urllib.parse import urlparse
-from pydantic import BaseModel, field_validator, ValidationInfo, Field
-from typing import Annotated
 from base64 import b64encode
+from typing import Callable, Dict, Optional
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 logger = logging.getLogger(__name__)
 

--- a/test/core/test_api_client.py
+++ b/test/core/test_api_client.py
@@ -6,7 +6,6 @@ import pytest
 
 from evo_client.core.api_client import ApiClient
 from evo_client.core.configuration import Configuration
-from evo_client.exceptions.api_exceptions import ApiClientError
 
 
 @pytest.fixture

--- a/test/core/test_configuration.py
+++ b/test/core/test_configuration.py
@@ -1,6 +1,7 @@
 import pytest
-from evo_client.core.configuration import Configuration
 from pydantic import ValidationError
+
+from evo_client.core.configuration import Configuration
 
 
 @pytest.fixture


### PR DESCRIPTION
There appear to be some python formatting errors in dd2d7f63a57e556c57be8a502a5060199b574468. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.