### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/core/configuration.py
+++ b/src/evo_client/core/configuration.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 import logging
 import multiprocessing
 import sys
-from base64 import b64encode
 from typing import Callable, Dict, Optional
 from urllib.parse import urlparse
-from requests.auth import HTTPBasicAuth
+
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
+from requests.auth import HTTPBasicAuth
 
 logger = logging.getLogger(__name__)
 

--- a/src/evo_client/core/response.py
+++ b/src/evo_client/core/response.py
@@ -1,5 +1,4 @@
 import io
-import json
 from typing import (
     Any,
     Dict,
@@ -44,10 +43,12 @@ class RESTResponse(io.IOBase):
         raise ValueError("Response content is not in JSON format")
 
     @overload
-    def deserialize(self, response_type: Type[T]) -> T: ...
+    def deserialize(self, response_type: Type[T]) -> T:
+        ...
 
     @overload
-    def deserialize(self, response_type: Type[Iterable[T]]) -> List[T]: ...
+    def deserialize(self, response_type: Type[Iterable[T]]) -> List[T]:
+        ...
 
     def deserialize(self, response_type: Type[T] | Type[Iterable[T]]) -> T | List[T]:
         """Deserialize response data into the specified type."""

--- a/src/evo_client/core/rest.py
+++ b/src/evo_client/core/rest.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import Any, Dict, Optional, TypeVar, Union
 

--- a/test/core/test_request_handler.py
+++ b/test/core/test_request_handler.py
@@ -1,8 +1,8 @@
 from unittest.mock import Mock
 
 import pytest
-from pydantic import BaseModel
 import requests
+from pydantic import BaseModel
 
 from evo_client.core.configuration import Configuration
 from evo_client.core.request_handler import RequestHandler

--- a/test/core/test_response.py
+++ b/test/core/test_response.py
@@ -5,7 +5,6 @@ import pytest
 import requests
 from pydantic import BaseModel
 
-
 from evo_client.core.response import RESTResponse
 from evo_client.exceptions.api_exceptions import ApiException
 

--- a/test/core/test_rest.py
+++ b/test/core/test_rest.py
@@ -1,6 +1,6 @@
 """Tests for the RESTClient class."""
 
-from typing import Any, Tuple
+from typing import Tuple
 from unittest.mock import Mock, patch
 
 import pytest


### PR DESCRIPTION
There appear to be some python formatting errors in f7135bb1d1f8eccc8be0e684b16d7804d70fe1ae. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.