### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/core/request_handler.py
+++ b/src/evo_client/core/request_handler.py
@@ -25,13 +25,16 @@ class RequestHandler:
         self.pool.join()
 
     @overload
-    def execute(self, response_type: None, **kwargs) -> Any: ...
+    def execute(self, response_type: None, **kwargs) -> Any:
+        ...
 
     @overload
-    def execute(self, response_type: Type[T], **kwargs) -> T: ...
+    def execute(self, response_type: Type[T], **kwargs) -> T:
+        ...
 
     @overload
-    def execute(self, response_type: Type[Iterable[T]], **kwargs) -> List[T]: ...
+    def execute(self, response_type: Type[Iterable[T]], **kwargs) -> List[T]:
+        ...
 
     def execute(
         self, response_type: Optional[Type[T] | Type[Iterable[T]]] = None, **kwargs
@@ -40,15 +43,18 @@ class RequestHandler:
         return self._make_request(response_type, **kwargs)
 
     @overload
-    def execute_async(self, response_type: None, **kwargs) -> AsyncResult[Any]: ...
+    def execute_async(self, response_type: None, **kwargs) -> AsyncResult[Any]:
+        ...
 
     @overload
-    def execute_async(self, response_type: Type[T], **kwargs) -> AsyncResult[T]: ...
+    def execute_async(self, response_type: Type[T], **kwargs) -> AsyncResult[T]:
+        ...
 
     @overload
     def execute_async(
         self, response_type: Type[Iterable[T]], **kwargs
-    ) -> AsyncResult[List[T]]: ...
+    ) -> AsyncResult[List[T]]:
+        ...
 
     def execute_async(
         self, response_type: Optional[Type[T] | Type[Iterable[T]]] = None, **kwargs

--- a/test/core/test_rest.py
+++ b/test/core/test_rest.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 from requests.auth import HTTPBasicAuth
+
 from evo_client.core.configuration import Configuration
 from evo_client.core.response import RESTResponse
 from evo_client.core.rest import RESTClient


### PR DESCRIPTION
There appear to be some python formatting errors in 7824cf724cd7455cb6f9e0af4713041b65ea347a. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.