### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/api/activities_api.py
+++ b/src/evo_client/api/activities_api.py
@@ -27,7 +27,8 @@ class ActivitiesApi:
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_activities(
@@ -37,7 +38,8 @@ class ActivitiesApi:
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: bool = False,
-    ) -> List[AtividadeListApiViewModel]: ...
+    ) -> List[AtividadeListApiViewModel]:
+        ...
 
     def get_activities(
         self,
@@ -76,7 +78,8 @@ class ActivitiesApi:
         activity_date: Optional[datetime] = None,
         session_id: Optional[int] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_schedule_detail(
@@ -85,7 +88,8 @@ class ActivitiesApi:
         activity_date: Optional[datetime] = None,
         session_id: Optional[int] = None,
         async_req: bool = False,
-    ) -> AtividadeBasicoApiViewModel: ...
+    ) -> AtividadeBasicoApiViewModel:
+        ...
 
     def get_schedule_detail(
         self,
@@ -133,7 +137,8 @@ class ActivitiesApi:
         slot_number: Optional[int] = None,
         origin: Optional[EOrigemAgendamento] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def enroll(
@@ -145,7 +150,8 @@ class ActivitiesApi:
         slot_number: Optional[int] = None,
         origin: Optional[EOrigemAgendamento] = None,
         async_req: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def enroll(
         self,
@@ -202,7 +208,8 @@ class ActivitiesApi:
         show_full_week: bool = False,
         branch_token: Optional[str] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_schedule(
@@ -217,7 +224,8 @@ class ActivitiesApi:
         show_full_week: bool = False,
         branch_token: Optional[str] = None,
         async_req: bool = False,
-    ) -> List[AtividadeSessaoParticipanteApiViewModel]: ...
+    ) -> List[AtividadeSessaoParticipanteApiViewModel]:
+        ...
 
     def get_schedule(
         self,
@@ -281,7 +289,8 @@ class ActivitiesApi:
         activity_exists: bool = False,
         branch_id: Optional[int] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def create_experimental_class(
@@ -293,7 +302,8 @@ class ActivitiesApi:
         activity_exists: bool = False,
         branch_id: Optional[int] = None,
         async_req: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def create_experimental_class(
         self,
@@ -333,7 +343,8 @@ class ActivitiesApi:
         activity_date: Optional[datetime] = None,
         session_id: Optional[int] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def change_status(
@@ -345,7 +356,8 @@ class ActivitiesApi:
         activity_date: Optional[datetime] = None,
         session_id: Optional[int] = None,
         async_req: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def change_status(
         self,
@@ -388,12 +400,14 @@ class ActivitiesApi:
     @overload
     def get_unavailable_spots(
         self, config_id: int, date: datetime, async_req: bool = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_unavailable_spots(
         self, config_id: int, date: datetime, async_req: bool = False
-    ) -> List[int]: ...
+    ) -> List[int]:
+        ...
 
     def get_unavailable_spots(
         self, config_id: int, date: datetime, async_req: bool = False

--- a/src/evo_client/api/configuration_api.py
+++ b/src/evo_client/api/configuration_api.py
@@ -13,7 +13,7 @@
 from __future__ import absolute_import
 
 from multiprocessing.pool import AsyncResult
-from typing import Any, Dict, List, Optional, Union, overload
+from typing import Any, List, Optional, Union, overload
 
 from evo_client.core.api_client import ApiClient
 
@@ -35,12 +35,14 @@ class ConfigurationApi:
     @overload
     def get_gateway_config(
         self, async_req: bool = True
-    ) -> Union[EmpresasFiliaisGatewayViewModel, AsyncResult[Any]]: ...
+    ) -> Union[EmpresasFiliaisGatewayViewModel, AsyncResult[Any]]:
+        ...
 
     @overload
     def get_gateway_config(
         self, async_req: bool = False
-    ) -> EmpresasFiliaisGatewayViewModel: ...
+    ) -> EmpresasFiliaisGatewayViewModel:
+        ...
 
     def get_gateway_config(
         self, async_req: bool = False
@@ -66,12 +68,12 @@ class ConfigurationApi:
     @overload
     def get_branch_config(
         self, async_req: bool = True
-    ) -> Union[ConfiguracaoApiViewModel, AsyncResult[Any]]: ...
+    ) -> Union[ConfiguracaoApiViewModel, AsyncResult[Any]]:
+        ...
 
     @overload
-    def get_branch_config(
-        self, async_req: bool = False
-    ) -> ConfiguracaoApiViewModel: ...
+    def get_branch_config(self, async_req: bool = False) -> ConfiguracaoApiViewModel:
+        ...
 
     def get_branch_config(
         self, async_req: bool = False
@@ -97,12 +99,14 @@ class ConfigurationApi:
     @overload
     def get_occupations(
         self, async_req: bool = True
-    ) -> Union[List[EmpresasFiliaisOcupacaoViewModel], AsyncResult[Any]]: ...
+    ) -> Union[List[EmpresasFiliaisOcupacaoViewModel], AsyncResult[Any]]:
+        ...
 
     @overload
     def get_occupations(
         self, async_req: bool = False
-    ) -> List[EmpresasFiliaisOcupacaoViewModel]: ...
+    ) -> List[EmpresasFiliaisOcupacaoViewModel]:
+        ...
 
     def get_occupations(
         self, async_req: bool = True
@@ -128,12 +132,12 @@ class ConfigurationApi:
     @overload
     def get_card_flags(
         self, async_req: bool = True
-    ) -> Union[List[BandeirasBasicoViewModel], AsyncResult[Any]]: ...
+    ) -> Union[List[BandeirasBasicoViewModel], AsyncResult[Any]]:
+        ...
 
     @overload
-    def get_card_flags(
-        self, async_req: bool = False
-    ) -> List[BandeirasBasicoViewModel]: ...
+    def get_card_flags(self, async_req: bool = False) -> List[BandeirasBasicoViewModel]:
+        ...
 
     def get_card_flags(
         self, async_req: bool = False
@@ -157,10 +161,12 @@ class ConfigurationApi:
         )
 
     @overload
-    def get_translations(self, async_req: bool = True) -> AsyncResult[Any]: ...
+    def get_translations(self, async_req: bool = True) -> AsyncResult[Any]:
+        ...
 
     @overload
-    def get_translations(self, async_req: bool = False) -> Any: ...
+    def get_translations(self, async_req: bool = False) -> Any:
+        ...
 
     def get_translations(self, async_req: bool = False) -> Union[Any, AsyncResult[Any]]:
         """

--- a/src/evo_client/api/employees_api.py
+++ b/src/evo_client/api/employees_api.py
@@ -25,7 +25,8 @@ class EmployeesApi:
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_employees(
@@ -36,7 +37,8 @@ class EmployeesApi:
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: bool = False,
-    ) -> List[FuncionariosResumoApiViewModel]: ...
+    ) -> List[FuncionariosResumoApiViewModel]:
+        ...
 
     def get_employees(
         self,
@@ -82,10 +84,12 @@ class EmployeesApi:
     @overload
     def delete_employee(
         self, employee_id: int, async_req: bool = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
-    def delete_employee(self, employee_id: int, async_req: bool = False) -> Any: ...
+    def delete_employee(self, employee_id: int, async_req: bool = False) -> Any:
+        ...
 
     def delete_employee(
         self, employee_id: int, async_req: bool = False
@@ -109,12 +113,14 @@ class EmployeesApi:
     @overload
     def update_employee(
         self, employee: EmployeeApiIntegracaoViewModel, async_req: bool = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def update_employee(
         self, employee: EmployeeApiIntegracaoViewModel, async_req: bool = False
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def update_employee(
         self, employee: EmployeeApiIntegracaoViewModel, async_req: bool = False
@@ -140,14 +146,16 @@ class EmployeesApi:
         self,
         employee: EmployeeApiIntegracaoAtualizacaoViewModel,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def create_employee(
         self,
         employee: EmployeeApiIntegracaoAtualizacaoViewModel,
         async_req: bool = False,
-    ) -> Union[Any, AsyncResult[Any]]: ...
+    ) -> Union[Any, AsyncResult[Any]]:
+        ...
 
     def create_employee(
         self,

--- a/src/evo_client/api/member_membership_api.py
+++ b/src/evo_client/api/member_membership_api.py
@@ -32,7 +32,8 @@ class MemberMembershipApi:
         add_fine: bool = False,
         value_fine: Optional[float] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def cancel_membership(
@@ -50,7 +51,8 @@ class MemberMembershipApi:
         add_fine: bool = False,
         value_fine: Optional[float] = None,
         async_req: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def cancel_membership(
         self,
@@ -113,12 +115,14 @@ class MemberMembershipApi:
     @overload
     def get_membership(
         self, id_member_membership: int, async_req: bool = True
-    ) -> MemberMembershipApiViewModel: ...
+    ) -> MemberMembershipApiViewModel:
+        ...
 
     @overload
     def get_membership(
         self, id_member_membership: int, async_req: bool = False
-    ) -> MemberMembershipApiViewModel: ...
+    ) -> MemberMembershipApiViewModel:
+        ...
 
     def get_membership(
         self, id_member_membership: int, async_req: bool = False
@@ -156,7 +160,8 @@ class MemberMembershipApi:
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: bool = True,
-    ) -> List[ContratosCanceladosResumoApiViewModel]: ...
+    ) -> List[ContratosCanceladosResumoApiViewModel]:
+        ...
 
     @overload
     def get_canceled_memberships(
@@ -175,7 +180,8 @@ class MemberMembershipApi:
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: bool = False,
-    ) -> List[ContratosCanceladosResumoApiViewModel]: ...
+    ) -> List[ContratosCanceladosResumoApiViewModel]:
+        ...
 
     def get_canceled_memberships(
         self,

--- a/src/evo_client/api/members_api.py
+++ b/src/evo_client/api/members_api.py
@@ -25,7 +25,8 @@ class MembersApi:
         password: str,
         change_password: bool = False,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def authenticate_member(
@@ -34,7 +35,8 @@ class MembersApi:
         password: str,
         change_password: bool = False,
         async_req: bool = False,
-    ) -> MemberAuthenticateViewModel: ...
+    ) -> MemberAuthenticateViewModel:
+        ...
 
     def authenticate_member(
         self,
@@ -78,7 +80,8 @@ class MembersApi:
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_basic_info(
@@ -90,7 +93,8 @@ class MembersApi:
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: bool = False,
-    ) -> MembersBasicApiViewModel: ...
+    ) -> MembersBasicApiViewModel:
+        ...
 
     def get_basic_info(
         self,
@@ -140,12 +144,14 @@ class MembersApi:
         )
 
     @overload
-    def get_fitcoins(self, id_member: int, async_req: bool = True) -> None: ...
+    def get_fitcoins(self, id_member: int, async_req: bool = True) -> None:
+        ...
 
     @overload
     def get_fitcoins(
         self, id_member: int, async_req: bool = False
-    ) -> Union[None, AsyncResult[Any]]: ...
+    ) -> Union[None, AsyncResult[Any]]:
+        ...
 
     def get_fitcoins(
         self, id_member: int, async_req: bool = False
@@ -160,7 +166,8 @@ class MembersApi:
         fitcoin: int,
         reason: Optional[str] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def update_fitcoins(
@@ -170,7 +177,8 @@ class MembersApi:
         fitcoin: int,
         reason: Optional[str] = None,
         async_req: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def update_fitcoins(
         self,
@@ -230,7 +238,8 @@ class MembersApi:
         personal_type: Optional[int] = None,
         show_activity_data: bool = False,
         async_req: bool = False,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_members(
@@ -256,7 +265,8 @@ class MembersApi:
         personal_type: Optional[int] = None,
         show_activity_data: bool = False,
         async_req: bool = False,
-    ) -> MemberDataViewModel: ...
+    ) -> MemberDataViewModel:
+        ...
 
     def get_members(
         self,
@@ -327,12 +337,14 @@ class MembersApi:
     @overload
     def update_member_card(
         self, id_member: int, card_number: str, async_req: bool = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def update_member_card(
         self, id_member: int, card_number: str, async_req: bool = False
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def update_member_card(
         self,
@@ -366,12 +378,14 @@ class MembersApi:
     @overload
     def get_member_profile(
         self, id_member: int, async_req: bool = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_member_profile(
         self, id_member: int, async_req: bool = False
-    ) -> MemberDataViewModel: ...
+    ) -> MemberDataViewModel:
+        ...
 
     def get_member_profile(
         self, id_member: int, async_req: bool = False
@@ -398,7 +412,8 @@ class MembersApi:
         user: str,
         sign_in: bool = False,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def reset_password(
@@ -406,7 +421,8 @@ class MembersApi:
         user: str,
         sign_in: bool = False,
         async_req: bool = False,
-    ) -> MemberAuthenticateViewModel: ...
+    ) -> MemberAuthenticateViewModel:
+        ...
 
     def reset_password(
         self,
@@ -442,14 +458,16 @@ class MembersApi:
         self,
         id_member: Optional[int] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_member_services(
         self,
         id_member: Optional[int] = None,
         async_req: bool = False,
-    ) -> list: ...
+    ) -> list:
+        ...
 
     def get_member_services(
         self,
@@ -480,12 +498,14 @@ class MembersApi:
     @overload
     def transfer_member(
         self, transfer_data: MemberTransferViewModel, async_req: bool = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def transfer_member(
         self, transfer_data: MemberTransferViewModel, async_req: bool = False
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def transfer_member(
         self, transfer_data: MemberTransferViewModel, async_req: bool = False
@@ -512,7 +532,8 @@ class MembersApi:
         id_member: int,
         body: MemberDataViewModel,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def update_member_data(
@@ -520,7 +541,8 @@ class MembersApi:
         id_member: int,
         body: MemberDataViewModel,
         async_req: bool = False,
-    ) -> bool: ...
+    ) -> bool:
+        ...
 
     def update_member_data(
         self,

--- a/src/evo_client/api/notifications_api.py
+++ b/src/evo_client/api/notifications_api.py
@@ -15,12 +15,14 @@ class NotificationsApi:
     @overload
     def create_notification(
         self, notification: NotificationApiViewModel, async_req: bool = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def create_notification(
         self, notification: NotificationApiViewModel, async_req: bool = False
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def create_notification(
         self, notification: NotificationApiViewModel, async_req: bool = False

--- a/src/evo_client/api/prospects_api.py
+++ b/src/evo_client/api/prospects_api.py
@@ -36,7 +36,8 @@ class ProspectsApi:
         skip: Optional[int] = None,
         gympass_id: Optional[str] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_prospects(
@@ -54,7 +55,8 @@ class ProspectsApi:
         skip: Optional[int] = None,
         gympass_id: Optional[str] = None,
         async_req: bool = False,
-    ) -> List[ProspectsResumoApiViewModel]: ...
+    ) -> List[ProspectsResumoApiViewModel]:
+        ...
 
     def get_prospects(
         self,
@@ -117,12 +119,14 @@ class ProspectsApi:
     @overload
     def create_prospect(
         self, prospect: ProspectApiIntegracaoViewModel, async_req: bool = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def create_prospect(
         self, prospect: ProspectApiIntegracaoViewModel, async_req: bool = False
-    ) -> ProspectIdViewModel: ...
+    ) -> ProspectIdViewModel:
+        ...
 
     def create_prospect(
         self, prospect: ProspectApiIntegracaoViewModel, async_req: bool = False
@@ -160,14 +164,16 @@ class ProspectsApi:
         self,
         prospect: ProspectApiIntegracaoAtualizacaoViewModel,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def update_prospect(
         self,
         prospect: ProspectApiIntegracaoAtualizacaoViewModel,
         async_req: bool = False,
-    ) -> ProspectIdViewModel: ...
+    ) -> ProspectIdViewModel:
+        ...
 
     def update_prospect(
         self,
@@ -203,12 +209,14 @@ class ProspectsApi:
     @overload
     def get_services(
         self, prospect_id: Optional[int] = None, async_req: bool = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_services(
         self, prospect_id: Optional[int] = None, async_req: bool = False
-    ) -> List[MemberServiceViewModel]: ...
+    ) -> List[MemberServiceViewModel]:
+        ...
 
     def get_services(
         self, prospect_id: Optional[int] = None, async_req: bool = False
@@ -234,12 +242,14 @@ class ProspectsApi:
     @overload
     def transfer_prospect(
         self, transfer: ProspectTransferenciaViewModel, async_req: bool = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def transfer_prospect(
         self, transfer: ProspectTransferenciaViewModel, async_req: bool = False
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def transfer_prospect(
         self, transfer: ProspectTransferenciaViewModel, async_req: bool = False

--- a/src/evo_client/api/receivables_api.py
+++ b/src/evo_client/api/receivables_api.py
@@ -51,7 +51,8 @@ class ReceivablesApi:
         sale_date_start: Optional[datetime] = None,
         sale_date_end: Optional[datetime] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_receivables(
@@ -87,7 +88,8 @@ class ReceivablesApi:
         sale_date_start: Optional[datetime] = None,
         sale_date_end: Optional[datetime] = None,
         async_req: bool = False,
-    ) -> List[ReceivablesApiViewModel]: ...
+    ) -> List[ReceivablesApiViewModel]:
+        ...
 
     def get_receivables(
         self,
@@ -211,7 +213,8 @@ class ReceivablesApi:
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_revenue_centers(
@@ -219,7 +222,8 @@ class ReceivablesApi:
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: bool = False,
-    ) -> RevenueCenterApiViewModel: ...
+    ) -> RevenueCenterApiViewModel:
+        ...
 
     def get_revenue_centers(
         self,
@@ -252,12 +256,14 @@ class ReceivablesApi:
     @overload
     def mark_received(
         self, receivables: ReceivablesMaskReceivedViewModel, async_req: bool = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def mark_received(
         self, receivables: ReceivablesMaskReceivedViewModel, async_req: bool = False
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def mark_received(
         self, receivables: ReceivablesMaskReceivedViewModel, async_req: bool = False

--- a/src/evo_client/api/states_api.py
+++ b/src/evo_client/api/states_api.py
@@ -12,10 +12,12 @@ class StatesApi:
         self.base_path = "/api/v1/states"
 
     @overload
-    def get_states(self, async_req: bool = True) -> AsyncResult[Any]: ...
+    def get_states(self, async_req: bool = True) -> AsyncResult[Any]:
+        ...
 
     @overload
-    def get_states(self, async_req: bool = False) -> Any: ...
+    def get_states(self, async_req: bool = False) -> Any:
+        ...
 
     def get_states(self, async_req: bool = False) -> Union[Any, AsyncResult[Any]]:
         """

--- a/src/evo_client/api/voucher_api.py
+++ b/src/evo_client/api/voucher_api.py
@@ -1,5 +1,5 @@
 from multiprocessing.pool import AsyncResult
-from typing import Any, Dict, List, Optional, Union, overload
+from typing import Any, List, Optional, Union, overload
 
 from ..core.api_client import ApiClient
 from ..models.vouchers_resumo_api_view_model import VouchersResumoApiViewModel
@@ -23,7 +23,8 @@ class VoucherApi:
         valid: Optional[bool] = None,
         voucher_type: Optional[int] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_vouchers(
@@ -36,7 +37,8 @@ class VoucherApi:
         valid: Optional[bool] = None,
         voucher_type: Optional[int] = None,
         async_req: bool = False,
-    ) -> List[VouchersResumoApiViewModel]: ...
+    ) -> List[VouchersResumoApiViewModel]:
+        ...
 
     def get_vouchers(
         self,
@@ -95,14 +97,16 @@ class VoucherApi:
         self,
         voucher_id: int,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_voucher_details(
         self,
         voucher_id: int,
         async_req: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def get_voucher_details(
         self,
@@ -143,7 +147,8 @@ class VoucherApi:
         usage_limit: Optional[int] = None,
         min_value: Optional[float] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def create_voucher(
@@ -157,7 +162,8 @@ class VoucherApi:
         usage_limit: Optional[int] = None,
         min_value: Optional[float] = None,
         async_req: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def create_voucher(
         self,

--- a/src/evo_client/api/webhook_api.py
+++ b/src/evo_client/api/webhook_api.py
@@ -1,5 +1,5 @@
 from multiprocessing.pool import AsyncResult
-from typing import Any, Dict, List, Optional, Union, overload
+from typing import Any, List, Optional, Union, overload
 
 from ..core.api_client import ApiClient
 from ..models.w12_utils_webhook_filter_view_model import W12UtilsWebhookFilterViewModel
@@ -17,10 +17,12 @@ class WebhookApi:
     @overload
     def delete_webhook(
         self, webhook_id: int, async_req: bool = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
-    def delete_webhook(self, webhook_id: int, async_req: bool = False) -> Any: ...
+    def delete_webhook(self, webhook_id: int, async_req: bool = False) -> Any:
+        ...
 
     def delete_webhook(
         self, webhook_id: int, async_req: bool = False
@@ -43,10 +45,12 @@ class WebhookApi:
         )
 
     @overload
-    def get_webhooks(self, async_req: bool = True) -> AsyncResult[Any]: ...
+    def get_webhooks(self, async_req: bool = True) -> AsyncResult[Any]:
+        ...
 
     @overload
-    def get_webhooks(self, async_req: bool = False) -> Any: ...
+    def get_webhooks(self, async_req: bool = False) -> Any:
+        ...
 
     def get_webhooks(self, async_req: bool = False) -> Union[Any, AsyncResult[Any]]:
         """
@@ -74,7 +78,8 @@ class WebhookApi:
         headers: Optional[List[W12UtilsWebhookHeaderViewModel]] = None,
         filters: Optional[List[W12UtilsWebhookFilterViewModel]] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def create_webhook(
@@ -85,7 +90,8 @@ class WebhookApi:
         headers: Optional[List[W12UtilsWebhookHeaderViewModel]] = None,
         filters: Optional[List[W12UtilsWebhookFilterViewModel]] = None,
         async_req: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def create_webhook(
         self,

--- a/src/evo_client/api/workout_api.py
+++ b/src/evo_client/api/workout_api.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from multiprocessing.pool import AsyncResult
-from typing import Any, Dict, List, Optional, Union, overload
+from typing import Any, Optional, Union, overload
 
 from ..core.api_client import ApiClient
 
@@ -26,7 +26,8 @@ class WorkoutApi:
         total_weeks: Optional[int] = None,
         weekly_frequency: Optional[int] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def update_workout(
@@ -42,7 +43,8 @@ class WorkoutApi:
         total_weeks: Optional[int] = None,
         weekly_frequency: Optional[int] = None,
         async_req: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def update_workout(
         self,
@@ -105,7 +107,8 @@ class WorkoutApi:
         inactive: Optional[bool] = None,
         deleted: Optional[bool] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_client_workouts(
@@ -117,7 +120,8 @@ class WorkoutApi:
         inactive: Optional[bool] = None,
         deleted: Optional[bool] = None,
         async_req: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def get_client_workouts(
         self,
@@ -167,7 +171,8 @@ class WorkoutApi:
         skip: Optional[int] = None,
         take: Optional[int] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_workouts_by_month_year_professor(
@@ -178,7 +183,8 @@ class WorkoutApi:
         skip: Optional[int] = None,
         take: Optional[int] = None,
         async_req: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def get_workouts_by_month_year_professor(
         self,
@@ -222,7 +228,8 @@ class WorkoutApi:
         employee_id: Optional[int] = None,
         tag_id: Optional[int] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def get_default_workouts(
@@ -230,7 +237,8 @@ class WorkoutApi:
         employee_id: Optional[int] = None,
         tag_id: Optional[int] = None,
         async_req: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def get_default_workouts(
         self,
@@ -278,7 +286,8 @@ class WorkoutApi:
         employee_id: Optional[int] = None,
         prescription_date: Optional[datetime] = None,
         async_req: bool = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def link_workout_to_client(
@@ -290,7 +299,8 @@ class WorkoutApi:
         employee_id: Optional[int] = None,
         prescription_date: Optional[datetime] = None,
         async_req: bool = False,
-    ) -> bool: ...
+    ) -> bool:
+        ...
 
     def link_workout_to_client(
         self,

--- a/test/api/test_configuration_api.py
+++ b/test/api/test_configuration_api.py
@@ -1,6 +1,6 @@
 """Tests for the ConfigurationApi class."""
 
-from typing import Any, Dict, List
+from typing import List
 from unittest.mock import Mock, patch
 
 import pytest


### PR DESCRIPTION
There appear to be some python formatting errors in 7c9adedd3879335695d5cbbfab7527d3dec178e1. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.