### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/utils/pagination_utils.py
+++ b/src/evo_client/utils/pagination_utils.py
@@ -1,7 +1,8 @@
-from typing import List, Any, Callable, Dict, TypeVar
-from loguru import logger
 import time
 from threading import Lock as ThreadLock
+from typing import Any, Callable, Dict, List, TypeVar
+
+from loguru import logger
 
 from ..exceptions.api_exceptions import ApiException
 


### PR DESCRIPTION
There appear to be some python formatting errors in 2066623f232e27115a39f14cbec8bfb5efe83784. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.