### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/api/member_membership_api.py
+++ b/src/evo_client/api/member_membership_api.py
@@ -34,7 +34,8 @@ class MemberMembershipApi(BaseApi):
         add_fine: bool = False,
         value_fine: Optional[float] = None,
         async_req: Literal[False] = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     @overload
     def cancel_membership(
@@ -52,7 +53,8 @@ class MemberMembershipApi(BaseApi):
         add_fine: bool = False,
         value_fine: Optional[float] = None,
         async_req: Literal[True] = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def cancel_membership(
         self,
@@ -115,12 +117,14 @@ class MemberMembershipApi(BaseApi):
     @overload
     def get_membership(
         self, id_member_membership: int, async_req: Literal[False] = False
-    ) -> MemberMembershipApiViewModel: ...
+    ) -> MemberMembershipApiViewModel:
+        ...
 
     @overload
     def get_membership(
         self, id_member_membership: int, async_req: Literal[True] = True
-    ) -> MemberMembershipApiViewModel: ...
+    ) -> MemberMembershipApiViewModel:
+        ...
 
     def get_membership(
         self, id_member_membership: int, async_req: bool = False
@@ -158,7 +162,8 @@ class MemberMembershipApi(BaseApi):
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: Literal[False] = False,
-    ) -> List[ContratosCanceladosResumoApiViewModel]: ...
+    ) -> List[ContratosCanceladosResumoApiViewModel]:
+        ...
 
     @overload
     def get_canceled_memberships(
@@ -177,7 +182,8 @@ class MemberMembershipApi(BaseApi):
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: Literal[True] = True,
-    ) -> List[ContratosCanceladosResumoApiViewModel]: ...
+    ) -> List[ContratosCanceladosResumoApiViewModel]:
+        ...
 
     def get_canceled_memberships(
         self,

--- a/src/evo_client/api/membership_api.py
+++ b/src/evo_client/api/membership_api.py
@@ -20,10 +20,12 @@ class MembershipApi(BaseApi):
     @overload
     def get_categories(
         self, async_req: Literal[False] = False
-    ) -> List[W12UtilsCategoryMembershipViewModel]: ...
+    ) -> List[W12UtilsCategoryMembershipViewModel]:
+        ...
 
     @overload
-    def get_categories(self, async_req: Literal[True] = True) -> AsyncResult[Any]: ...
+    def get_categories(self, async_req: Literal[True] = True) -> AsyncResult[Any]:
+        ...
 
     def get_categories(
         self, async_req: bool = False
@@ -47,7 +49,8 @@ class MembershipApi(BaseApi):
         skip: Optional[int] = None,
         active: Optional[bool] = None,
         async_req: Literal[False] = False,
-    ) -> List[ContratosResumoApiViewModel]: ...
+    ) -> List[ContratosResumoApiViewModel]:
+        ...
 
     @overload
     def get_memberships(
@@ -59,7 +62,8 @@ class MembershipApi(BaseApi):
         skip: Optional[int] = None,
         active: Optional[bool] = None,
         async_req: Literal[True] = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def get_memberships(
         self,

--- a/src/evo_client/api/sales_api.py
+++ b/src/evo_client/api/sales_api.py
@@ -20,12 +20,14 @@ class SalesApi(BaseApi):
     @overload
     def get_sale_by_id(
         self, sale_id: int, async_req: Literal[False] = False
-    ) -> SalesViewModel: ...
+    ) -> SalesViewModel:
+        ...
 
     @overload
     def get_sale_by_id(
         self, sale_id: int, async_req: Literal[True] = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def get_sale_by_id(
         self, sale_id: int, async_req: bool = False
@@ -45,12 +47,14 @@ class SalesApi(BaseApi):
     @overload
     def create_sale(
         self, body: Optional[NewSaleViewModel] = None, async_req: Literal[False] = False
-    ) -> NewSaleResponse: ...
+    ) -> NewSaleResponse:
+        ...
 
     @overload
     def create_sale(
         self, body: Optional[NewSaleViewModel] = None, async_req: Literal[True] = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def create_sale(
         self, body: Optional[NewSaleViewModel] = None, async_req: bool = False
@@ -96,7 +100,8 @@ class SalesApi(BaseApi):
         show_allow_locker: Optional[bool] = None,
         only_total_pass: Optional[bool] = None,
         async_req: Literal[False] = False,
-    ) -> List[SalesViewModel]: ...
+    ) -> List[SalesViewModel]:
+        ...
 
     @overload
     def get_sales(
@@ -118,7 +123,8 @@ class SalesApi(BaseApi):
         show_allow_locker: Optional[bool] = None,
         only_total_pass: Optional[bool] = None,
         async_req: Literal[True] = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def get_sales(
         self,
@@ -192,12 +198,14 @@ class SalesApi(BaseApi):
     @overload
     def get_sales_items(
         self, branch_id: Optional[int] = None, async_req: Literal[False] = False
-    ) -> List[SalesItemsViewModel]: ...
+    ) -> List[SalesItemsViewModel]:
+        ...
 
     @overload
     def get_sales_items(
         self, branch_id: Optional[int] = None, async_req: Literal[True] = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def get_sales_items(
         self, branch_id: Optional[int] = None, async_req: bool = False
@@ -220,7 +228,8 @@ class SalesApi(BaseApi):
         session_id: str,
         date: Optional[datetime] = None,
         async_req: Literal[False] = False,
-    ) -> int: ...
+    ) -> int:
+        ...
 
     @overload
     def get_sale_by_session_id(
@@ -228,7 +237,8 @@ class SalesApi(BaseApi):
         session_id: str,
         date: Optional[datetime] = None,
         async_req: Literal[True] = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def get_sale_by_session_id(
         self, session_id: str, date: Optional[datetime] = None, async_req: bool = False


### PR DESCRIPTION
There appear to be some python formatting errors in 0e18487943576e9e83fcc4880c6aad74c5f3e8a4. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.