### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/api/membership_api.py
+++ b/src/evo_client/api/membership_api.py
@@ -2,6 +2,7 @@ from multiprocessing.pool import AsyncResult
 from typing import Any, List, Literal, Optional, Union, overload
 
 from loguru import logger
+
 from ..core.api_client import ApiClient
 from ..models.contratos_resumo_api_view_model import (
     ContratosResumoApiViewModel,


### PR DESCRIPTION
There appear to be some python formatting errors in 7b1293b086c8df0df4333bd345c9d1f4cf3c7963. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.