### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/api/membership_api.py
+++ b/src/evo_client/api/membership_api.py
@@ -52,7 +52,8 @@ class MembershipApi(BaseApi):
         active: Optional[bool] = None,
         version: Literal["v1"] = "v1",
         async_req: Literal[False] = False,
-    ) -> List[ContratosResumoApiViewModel]: ...
+    ) -> List[ContratosResumoApiViewModel]:
+        ...
 
     @overload
     def get_memberships(
@@ -78,9 +79,9 @@ class MembershipApi(BaseApi):
         active: Optional[bool] = None,
         version: Literal["v1", "v2"] = "v2",
         async_req: Literal[False] = False,
-    ) -> Union[
-        List[ContratosResumoApiViewModel], ContratosResumoContainerViewModel
-    ]: ...
+    ) -> Union[List[ContratosResumoApiViewModel], ContratosResumoContainerViewModel]:
+        ...
+
     @overload
     def get_memberships(
         self,


### PR DESCRIPTION
There appear to be some python formatting errors in 48c620398039574dc607382f9b970e33dad2bdc8. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.