### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/api/membership_api.py
+++ b/src/evo_client/api/membership_api.py
@@ -55,7 +55,8 @@ class MembershipApi(BaseApi):
         active: Optional[bool] = None,
         version: Literal["v1"] = "v1",
         async_req: Literal[False] = False,
-    ) -> List[ContratosResumoApiViewModel]: ...
+    ) -> List[ContratosResumoApiViewModel]:
+        ...
 
     @overload
     def get_memberships(
@@ -82,9 +83,9 @@ class MembershipApi(BaseApi):
         active: Optional[bool] = None,
         version: Literal["v1", "v2"] = "v2",
         async_req: Literal[False] = False,
-    ) -> Union[
-        List[ContratosResumoApiViewModel], ContratosResumoContainerViewModel
-    ]: ...
+    ) -> Union[List[ContratosResumoApiViewModel], ContratosResumoContainerViewModel]:
+        ...
+
     @overload
     def get_memberships(
         self,


### PR DESCRIPTION
There appear to be some python formatting errors in 0fea7e1bb3d8613a07027c1bf94b1cfa87512987. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.