### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/api/activities_api.py
+++ b/src/evo_client/api/activities_api.py
@@ -26,7 +26,8 @@ class ActivitiesApi(BaseApi):
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: Literal[False] = False,
-    ) -> List[AtividadeListApiViewModel]: ...
+    ) -> List[AtividadeListApiViewModel]:
+        ...
 
     @overload
     def get_activities(
@@ -36,7 +37,8 @@ class ActivitiesApi(BaseApi):
         take: Optional[int] = None,
         skip: Optional[int] = None,
         async_req: Literal[True] = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def get_activities(
         self,
@@ -75,7 +77,8 @@ class ActivitiesApi(BaseApi):
         activity_date: Optional[datetime] = None,
         session_id: Optional[int] = None,
         async_req: Literal[False] = False,
-    ) -> AtividadeBasicoApiViewModel: ...
+    ) -> AtividadeBasicoApiViewModel:
+        ...
 
     @overload
     def get_schedule_detail(
@@ -84,7 +87,8 @@ class ActivitiesApi(BaseApi):
         activity_date: Optional[datetime] = None,
         session_id: Optional[int] = None,
         async_req: Literal[True] = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def get_schedule_detail(
         self,
@@ -132,7 +136,8 @@ class ActivitiesApi(BaseApi):
         slot_number: Optional[int] = None,
         origin: Optional[EOrigemAgendamento] = None,
         async_req: Literal[False] = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     @overload
     def enroll(
@@ -144,7 +149,8 @@ class ActivitiesApi(BaseApi):
         slot_number: Optional[int] = None,
         origin: Optional[EOrigemAgendamento] = None,
         async_req: Literal[True] = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def enroll(
         self,
@@ -201,7 +207,8 @@ class ActivitiesApi(BaseApi):
         show_full_week: bool = False,
         branch_token: Optional[str] = None,
         async_req: Literal[False] = False,
-    ) -> List[AtividadeAgendaApiViewModel]: ...
+    ) -> List[AtividadeAgendaApiViewModel]:
+        ...
 
     @overload
     def get_schedule(
@@ -216,7 +223,8 @@ class ActivitiesApi(BaseApi):
         show_full_week: bool = False,
         branch_token: Optional[str] = None,
         async_req: Literal[True] = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def get_schedule(
         self,
@@ -280,7 +288,8 @@ class ActivitiesApi(BaseApi):
         activity_exists: bool = False,
         branch_id: Optional[int] = None,
         async_req: Literal[False] = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     @overload
     def create_experimental_class(
@@ -292,7 +301,8 @@ class ActivitiesApi(BaseApi):
         activity_exists: bool = False,
         branch_id: Optional[int] = None,
         async_req: Literal[True] = True,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def create_experimental_class(
         self,
@@ -332,7 +342,8 @@ class ActivitiesApi(BaseApi):
         activity_date: Optional[datetime] = None,
         session_id: Optional[int] = None,
         async_req: Literal[False] = False,
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     @overload
     def change_status(
@@ -344,7 +355,8 @@ class ActivitiesApi(BaseApi):
         activity_date: Optional[datetime] = None,
         session_id: Optional[int] = None,
         async_req: Literal[True] = True,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def change_status(
         self,
@@ -387,12 +399,14 @@ class ActivitiesApi(BaseApi):
     @overload
     def get_unavailable_spots(
         self, config_id: int, date: datetime, async_req: Literal[False] = False
-    ) -> List[int]: ...
+    ) -> List[int]:
+        ...
 
     @overload
     def get_unavailable_spots(
         self, config_id: int, date: datetime, async_req: Literal[True] = True
-    ) -> AsyncResult[Any]: ...
+    ) -> AsyncResult[Any]:
+        ...
 
     def get_unavailable_spots(
         self, config_id: int, date: datetime, async_req: bool = False

--- a/test/api/test_activities_api.py
+++ b/test/api/test_activities_api.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from loguru import logger
+
 from evo_client.api.activities_api import ActivitiesApi
 from evo_client.exceptions.api_exceptions import ApiException
 from evo_client.models.atividade_basico_api_view_model import (


### PR DESCRIPTION
There appear to be some python formatting errors in 7312eb5a9de7433bdc51fcada0d5737c7675d44a. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.