### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/aio/__init__.py
+++ b/src/evo_client/aio/__init__.py
@@ -5,8 +5,6 @@ from .api import (
     AsyncActivitiesApi,
     AsyncBankAccountsApi,
     AsyncBaseApi,
-    AsyncVoucherApi,
-    AsyncWorkoutApi,
     AsyncConfigurationApi,
     AsyncEmployeesApi,
     AsyncEntriesApi,
@@ -24,7 +22,9 @@ from .api import (
     AsyncSalesApi,
     AsyncServiceApi,
     AsyncStatesApi,
+    AsyncVoucherApi,
     AsyncWebhookApi,
+    AsyncWorkoutApi,
 )
 from .core.api_client import AsyncApiClient
 

--- a/src/evo_client/aio/api/__init__.py
+++ b/src/evo_client/aio/api/__init__.py
@@ -3,14 +3,12 @@
 from .activities_api import AsyncActivitiesApi
 from .bank_accounts_api import AsyncBankAccountsApi
 from .base import AsyncBaseApi
-from .voucher_api import AsyncVoucherApi
-from .member_membership_api import AsyncMemberMembershipApi
-from .workout_api import AsyncWorkoutApi
-from .employees_api import AsyncEmployeesApi
 from .configuration_api import AsyncConfigurationApi
+from .employees_api import AsyncEmployeesApi
 from .entries_api import AsyncEntriesApi
 from .invoices_api import AsyncInvoicesApi
 from .management_api import AsyncManagementApi
+from .member_membership_api import AsyncMemberMembershipApi
 from .members_api import AsyncMembersApi
 from .membership_api import AsyncMembershipApi
 from .notifications_api import AsyncNotificationsApi
@@ -22,7 +20,9 @@ from .receivables_api import AsyncReceivablesApi
 from .sales_api import AsyncSalesApi
 from .service_api import AsyncServiceApi
 from .states_api import AsyncStatesApi
+from .voucher_api import AsyncVoucherApi
 from .webhook_api import AsyncWebhookApi
+from .workout_api import AsyncWorkoutApi
 
 __all__ = [
     "AsyncBaseApi",

--- a/src/evo_client/sync/__init__.py
+++ b/src/evo_client/sync/__init__.py
@@ -4,8 +4,6 @@
 from .api import (
     SyncActivitiesApi,
     SyncBankAccountsApi,
-    SyncVoucherApi,
-    SyncWorkoutApi,
     SyncConfigurationApi,
     SyncEmployeesApi,
     SyncEntriesApi,
@@ -23,7 +21,9 @@ from .api import (
     SyncSalesApi,
     SyncServiceApi,
     SyncStatesApi,
+    SyncVoucherApi,
     SyncWebhookApi,
+    SyncWorkoutApi,
 )
 from .api.base import SyncBaseApi
 from .core.api_client import SyncApiClient

--- a/src/evo_client/sync/api/__init__.py
+++ b/src/evo_client/sync/api/__init__.py
@@ -3,14 +3,12 @@
 from .activities_api import SyncActivitiesApi
 from .bank_accounts_api import SyncBankAccountsApi
 from .base import SyncBaseApi
-from .voucher_api import SyncVoucherApi
-from .member_membership_api import SyncMemberMembershipApi
-from .workout_api import SyncWorkoutApi
-from .employees_api import SyncEmployeesApi
 from .configuration_api import SyncConfigurationApi
+from .employees_api import SyncEmployeesApi
 from .entries_api import SyncEntriesApi
 from .invoices_api import SyncInvoicesApi
 from .management_api import SyncManagementApi
+from .member_membership_api import SyncMemberMembershipApi
 from .members_api import SyncMembersApi
 from .membership_api import SyncMembershipApi
 from .notifications_api import SyncNotificationsApi
@@ -22,7 +20,9 @@ from .receivables_api import SyncReceivablesApi
 from .sales_api import SyncSalesApi
 from .service_api import SyncServiceApi
 from .states_api import SyncStatesApi
+from .voucher_api import SyncVoucherApi
 from .webhook_api import SyncWebhookApi
+from .workout_api import SyncWorkoutApi
 
 __all__ = [
     "SyncBaseApi",

--- a/src/evo_client/sync/api/activities_api.py
+++ b/src/evo_client/sync/api/activities_api.py
@@ -9,9 +9,9 @@ from ...models.atividade_list_api_view_model import AtividadeListApiViewModel
 from ...models.atividade_lugar_reserva_api_view_model import (
     AtividadeLugarReservaApiViewModel,
 )
+from ...models.common_models import ActivityOperationResponse
 from ...models.e_origem_agendamento import EOrigemAgendamento
 from ...models.e_status_atividade_sessao import EStatusAtividadeSessao
-from ...models.common_models import ActivityOperationResponse
 from .base import SyncBaseApi
 
 

--- a/src/evo_client/sync/api/voucher_api.py
+++ b/src/evo_client/sync/api/voucher_api.py
@@ -1,13 +1,10 @@
 """Clean synchronous Voucher API."""
 
-from typing import List, Optional, cast, Any
 import json
+from typing import Any, List, Optional, cast
 
+from ...models.voucher_models import VoucherCreateResponse, VoucherDetails
 from ...models.vouchers_resumo_api_view_model import VouchersResumoApiViewModel
-from ...models.voucher_models import (
-    VoucherDetails,
-    VoucherCreateResponse,
-)
 from .base import SyncBaseApi
 
 

--- a/test/aio/api/test_async_voucher_api.py
+++ b/test/aio/api/test_async_voucher_api.py
@@ -4,8 +4,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from evo_client.aio.api import AsyncVoucherApi
 from evo_client.aio import AsyncApiClient
+from evo_client.aio.api import AsyncVoucherApi
 from evo_client.exceptions.api_exceptions import ApiException
 from evo_client.models.vouchers_resumo_api_view_model import VouchersResumoApiViewModel
 

--- a/test/aio/api/test_async_workout_api.py
+++ b/test/aio/api/test_async_workout_api.py
@@ -5,8 +5,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from evo_client.aio.api import AsyncWorkoutApi
 from evo_client.aio import AsyncApiClient
+from evo_client.aio.api import AsyncWorkoutApi
 from evo_client.exceptions.api_exceptions import ApiException
 
 
@@ -78,7 +78,9 @@ async def test_get_client_workouts(workout_api: AsyncWorkoutApi, mock_api_client
 
 
 @pytest.mark.asyncio
-async def test_get_default_workouts(workout_api: AsyncWorkoutApi, mock_api_client: Mock):
+async def test_get_default_workouts(
+    workout_api: AsyncWorkoutApi, mock_api_client: Mock
+):
     """Test getting default workouts."""
     expected = [{"id": 1, "name": "Default Workout"}]
     mock_api_client.return_value = expected
@@ -99,7 +101,9 @@ async def test_get_default_workouts(workout_api: AsyncWorkoutApi, mock_api_clien
 
 
 @pytest.mark.asyncio
-async def test_link_workout_to_client(workout_api: AsyncWorkoutApi, mock_api_client: Mock):
+async def test_link_workout_to_client(
+    workout_api: AsyncWorkoutApi, mock_api_client: Mock
+):
     """Test linking workout to client."""
     expected = True
     mock_api_client.return_value = expected

--- a/test/api/test_voucher_api.py
+++ b/test/api/test_voucher_api.py
@@ -4,10 +4,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from evo_client.sync.api import SyncVoucherApi
-from evo_client.sync import SyncApiClient
 from evo_client.exceptions.api_exceptions import ApiException
 from evo_client.models.vouchers_resumo_api_view_model import VouchersResumoApiViewModel
+from evo_client.sync import SyncApiClient
+from evo_client.sync.api import SyncVoucherApi
 
 
 @pytest.fixture

--- a/test/consistency/test_api_consistency.py
+++ b/test/consistency/test_api_consistency.py
@@ -174,7 +174,7 @@ class TestAPIConsistencyMarked:
 
     def test_api_consistency_marked(self, consistency_results, report_generator):
         """Test marked with consistency marker."""
-        report = report_generator(consistency_results)
+        report_generator(consistency_results)
 
         # This test is marked for easy running with: pytest -m consistency
         # It won't fail but will report current state

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -94,39 +94,10 @@ class TestPhase4ImportPatterns:
     def test_all_22_apis_accessible(self):
         """Test that all 22 APIs are accessible through new import patterns."""
         # Test sync APIs
-        from evo_client.sync.api import (
-            SyncMembersApi,
-            SyncSalesApi,
-            SyncActivitiesApi,
-            SyncMembershipApi,
-            SyncReceivablesApi,
-            SyncPayablesApi,
-            SyncEntriesApi,
-            SyncProspectsApi,
-            SyncInvoicesApi,
-            SyncPixApi,
-            SyncBankAccountsApi,
-            SyncVoucherApi,
-            SyncMemberMembershipApi,
-            SyncWorkoutApi,
-            SyncEmployeesApi,
-            SyncConfigurationApi,
-            SyncStatesApi,
-            SyncServiceApi,
-            SyncManagementApi,
-            SyncNotificationsApi,
-            SyncWebhookApi,
-            SyncPartnershipApi,
-        )
-
         # Test async APIs
         from evo_client.aio.api import (
             AsyncActivitiesApi,
             AsyncBankAccountsApi,
-            AsyncVoucherApi,
-            AsyncMemberMembershipApi,
-            AsyncWorkoutApi,
-            AsyncEmployeesApi,
             AsyncConfigurationApi,
             AsyncEmployeesApi,
             AsyncEntriesApi,
@@ -144,7 +115,9 @@ class TestPhase4ImportPatterns:
             AsyncSalesApi,
             AsyncServiceApi,
             AsyncStatesApi,
+            AsyncVoucherApi,
             AsyncWebhookApi,
+            AsyncWorkoutApi,
         )
         from evo_client.sync.api import (
             SyncActivitiesApi,
@@ -166,7 +139,9 @@ class TestPhase4ImportPatterns:
             SyncSalesApi,
             SyncServiceApi,
             SyncStatesApi,
+            SyncVoucherApi,
             SyncWebhookApi,
+            SyncWorkoutApi,
         )
 
         # Verify all APIs are not None (basic import test)

--- a/test/services/data_fetchers/test_member_data_fetcher.py
+++ b/test/services/data_fetchers/test_member_data_fetcher.py
@@ -5,15 +5,12 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from evo_client.services.data_fetchers.member_data_fetcher import MemberDataFetcher
-from evo_client.services.data_fetchers import (
-    BaseDataFetcher,
-    BranchApiClientManager,
-)
 from evo_client.models.cliente_detalhes_basicos_api_view_model import (
     ClienteDetalhesBasicosApiViewModel,
 )
 from evo_client.models.members_api_view_model import MembersApiViewModel
+from evo_client.services.data_fetchers import BaseDataFetcher, BranchApiClientManager
+from evo_client.services.data_fetchers.member_data_fetcher import MemberDataFetcher
 
 
 class TestMemberDataFetcher:


### PR DESCRIPTION
There appear to be some python formatting errors in 1a491090dc786553511e016fef0d471a26ea0f36. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.