### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/evo_client/aio/api/membership_api.py
+++ b/src/evo_client/aio/api/membership_api.py
@@ -2,9 +2,7 @@
 
 from typing import List, Optional, cast
 
-from ...models.contratos_resumo_api_view_model import (
-    ContratosResumoContainerViewModel,
-)
+from ...models.contratos_resumo_api_view_model import ContratosResumoContainerViewModel
 from ...models.w12_utils_category_membership_view_model import (
     W12UtilsCategoryMembershipViewModel,
 )

--- a/src/evo_client/aio/core/api_client.py
+++ b/src/evo_client/aio/core/api_client.py
@@ -78,7 +78,8 @@ class AsyncApiClient:
         preload_content: bool = True,
         request_timeout: Optional[Union[float, tuple]] = None,
         raw_response: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     @overload
     async def call_api(
@@ -98,7 +99,8 @@ class AsyncApiClient:
         preload_content: bool = True,
         request_timeout: Optional[Union[float, tuple]] = None,
         raw_response: bool = False,
-    ) -> T: ...
+    ) -> T:
+        ...
 
     @overload
     async def call_api(
@@ -118,7 +120,8 @@ class AsyncApiClient:
         preload_content: bool = True,
         request_timeout: Optional[Union[float, tuple]] = None,
         raw_response: bool = False,
-    ) -> List[T]: ...
+    ) -> List[T]:
+        ...
 
     @overload
     async def call_api(
@@ -138,7 +141,8 @@ class AsyncApiClient:
         preload_content: bool = True,
         request_timeout: Optional[Union[float, tuple]] = None,
         raw_response: bool = True,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     async def call_api(
         self,

--- a/src/evo_client/core/response.py
+++ b/src/evo_client/core/response.py
@@ -51,10 +51,12 @@ class RESTResponse(io.IOBase):
             raise e
 
     @overload
-    def deserialize(self, response_type: Type[T]) -> T: ...
+    def deserialize(self, response_type: Type[T]) -> T:
+        ...
 
     @overload
-    def deserialize(self, response_type: Type[Iterable[T]]) -> List[T]: ...
+    def deserialize(self, response_type: Type[Iterable[T]]) -> List[T]:
+        ...
 
     def deserialize(self, response_type: Type[T] | Type[Iterable[T]]) -> T | List[T]:
         """Deserialize response data into the specified type."""

--- a/src/evo_client/sync/api/membership_api.py
+++ b/src/evo_client/sync/api/membership_api.py
@@ -2,9 +2,7 @@
 
 from typing import List, Optional, cast
 
-from ...models.contratos_resumo_api_view_model import (
-    ContratosResumoContainerViewModel,
-)
+from ...models.contratos_resumo_api_view_model import ContratosResumoContainerViewModel
 from ...models.w12_utils_category_membership_view_model import (
     W12UtilsCategoryMembershipViewModel,
 )

--- a/src/evo_client/sync/core/api_client.py
+++ b/src/evo_client/sync/core/api_client.py
@@ -66,7 +66,8 @@ class SyncApiClient:
         _preload_content: bool = True,
         _request_timeout: Optional[Union[float, tuple]] = None,
         raw_response: bool = False,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     @overload
     def call_api(
@@ -86,7 +87,8 @@ class SyncApiClient:
         _preload_content: bool = True,
         _request_timeout: Optional[Union[float, tuple]] = None,
         raw_response: bool = False,
-    ) -> T: ...
+    ) -> T:
+        ...
 
     @overload
     def call_api(
@@ -106,7 +108,8 @@ class SyncApiClient:
         _preload_content: bool = True,
         _request_timeout: Optional[Union[float, tuple]] = None,
         raw_response: bool = False,
-    ) -> List[T]: ...
+    ) -> List[T]:
+        ...
 
     @overload
     def call_api(
@@ -126,7 +129,8 @@ class SyncApiClient:
         _preload_content: bool = True,
         _request_timeout: Optional[Union[float, tuple]] = None,
         raw_response: bool = True,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def call_api(
         self,

--- a/test/aio/api/test_async_managment_api.py
+++ b/test/aio/api/test_async_managment_api.py
@@ -336,9 +336,11 @@ async def test_get_non_renewed_clients_unexpected_error(
 
 def test_convert_value():
     """Test the convert_value utility function."""
-    from evo_client.aio.api.management_api import convert_value
     from datetime import datetime
+
     import pandas as pd
+
+    from evo_client.aio.api.management_api import convert_value
 
     # Test with None/NaN values
     assert convert_value(None, str) is None

--- a/test/aio/api/test_async_notifications_api.py
+++ b/test/aio/api/test_async_notifications_api.py
@@ -105,7 +105,7 @@ async def test_error_handling(
 ):
     """Test API error handling."""
     mock_api_client.side_effect = ApiException(status=500, reason="Server Error")
-    notification_data = NotificationApiViewModel()
+    NotificationApiViewModel()
 
     with pytest.raises(ApiException) as exc:
         await notifications_api.insert_member_notification(

--- a/test/aio/core/test_async_request_handler.py
+++ b/test/aio/core/test_async_request_handler.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import aiohttp
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from evo_client.aio.core.request_handler import AsyncRequestHandler, AsyncRESTResponse
 from evo_client.core.configuration import Configuration

--- a/test/api/test_managment_api.py
+++ b/test/api/test_managment_api.py
@@ -302,9 +302,11 @@ def test_get_non_renewed_clients_unexpected_error(
 
 def test_convert_value():
     """Test the convert_value utility function."""
-    from evo_client.sync.api.management_api import convert_value
     from datetime import datetime
+
     import pandas as pd
+
+    from evo_client.sync.api.management_api import convert_value
 
     # Test with None/NaN values
     assert convert_value(None, str) is None

--- a/test/api/test_notifications_api.py
+++ b/test/api/test_notifications_api.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from evo_client.models.notification_api_view_model import NotificationApiViewModel
 from evo_client.sync import SyncApiClient
 from evo_client.sync.api import SyncNotificationsApi
 

--- a/test/config/test_config_builder.py
+++ b/test/config/test_config_builder.py
@@ -1,8 +1,6 @@
 """Tests for config builder functionality."""
 
-from unittest.mock import Mock, patch
-
-import pytest
+from unittest.mock import patch
 
 from evo_client.config.builder import ConfigBuilder, QuickConfig
 from evo_client.core.configuration import Configuration

--- a/test/config/test_config_validator.py
+++ b/test/config/test_config_validator.py
@@ -1,6 +1,5 @@
 """Tests for config validator functionality."""
 
-import pytest
 
 from evo_client.config.validator import ConfigValidator
 from evo_client.core.configuration import Configuration

--- a/test/consistency/conftest.py
+++ b/test/consistency/conftest.py
@@ -90,7 +90,6 @@ class RouteExtractor:
                     isinstance(node.func, ast.Attribute)
                     and node.func.attr == "call_api"
                 ):
-
                     # Find resource_path argument
                     for keyword in node.keywords:
                         if keyword.arg == "resource_path":

--- a/test/consistency/test_api_consistency.py
+++ b/test/consistency/test_api_consistency.py
@@ -81,9 +81,7 @@ class TestAPIConsistency:
                 + "\n".join(issues)
             )
 
-        print(
-            "✅ All API routes are consistent between sync and async implementations"
-        )
+        print("✅ All API routes are consistent between sync and async implementations")
 
     @pytest.mark.parametrize(
         "api_name",

--- a/test/sync/core/test_sync_request_handler.py
+++ b/test/sync/core/test_sync_request_handler.py
@@ -1,6 +1,5 @@
 """Tests for the SyncRequestHandler class."""
 
-import json
 from unittest.mock import Mock, patch
 
 import pytest

--- a/test/utils/test_async_pagination_utils_enhanced.py
+++ b/test/utils/test_async_pagination_utils_enhanced.py
@@ -1,7 +1,5 @@
 """Enhanced tests for async pagination utilities to cover missing coverage lines."""
 
-import asyncio
-from typing import Any, Dict, List
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -220,7 +218,6 @@ class TestConcurrentPaginationManagerEnhanced:
         ) as mock_semaphore, patch(
             "asyncio.sleep"
         ):  # Mock any sleep calls
-
             # Setup mock instances
             mock_executor = Mock()
             mock_caller = Mock()


### PR DESCRIPTION
There appear to be some python formatting errors in 6963733a3d2c7fb8f7007dec986f3f82dad5c1ce. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.