### PR TITLE
Fix bool query parameters for aiohttp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo_client"
-version = "2.0.2"
+version = "2.0.3"
 description = "ABC Evo SDK"
 authors = [
     {email = "support@evo.com"}

--- a/src/evo_client/aio/core/request_handler.py
+++ b/src/evo_client/aio/core/request_handler.py
@@ -86,8 +86,26 @@ class AsyncRequestHandler:
         return headers
 
     def _prepare_params(self, query_params: Optional[Dict] = None) -> Dict:
-        """Prepare query parameters."""
-        return query_params or {}
+        """Prepare query parameters for aiohttp.
+
+        The underlying ``aiohttp`` request builder only accepts ``str``, ``int``
+        or ``float`` types. Boolean values must be converted to strings or they
+        will raise a ``TypeError`` when building the request.
+        """
+
+        if not query_params:
+            return {}
+
+        prepared: Dict[str, Any] = {}
+        for key, value in query_params.items():
+            if value is None:
+                continue
+            if isinstance(value, bool):
+                prepared[key] = str(value).lower()
+            else:
+                prepared[key] = value
+
+        return prepared
 
     async def execute(
         self, response_type: Optional[Type[T] | Type[Iterable[T]]] = None, **kwargs

--- a/src/evo_client/aio/core/request_handler.py
+++ b/src/evo_client/aio/core/request_handler.py
@@ -85,7 +85,7 @@ class AsyncRequestHandler:
             headers.update(header_params)
         return headers
 
-    def _prepare_params(self, query_params: Optional[Dict] = None) -> Dict:
+    def _prepare_params(self, query_params: Optional[Dict] = None) -> Dict[str, Any]:
         """Prepare query parameters for aiohttp.
 
         The underlying ``aiohttp`` request builder only accepts ``str``, ``int``

--- a/src/evo_client/sync/core/request_handler.py
+++ b/src/evo_client/sync/core/request_handler.py
@@ -36,8 +36,25 @@ class SyncRequestHandler:
         return headers
 
     def _prepare_params(self, query_params: Optional[Dict] = None) -> Dict:
-        """Prepare query parameters."""
-        return query_params or {}
+        """Prepare query parameters.
+
+        Boolean values are converted to lowercase strings so that sync and async
+        implementations behave the same when sending query parameters.
+        """
+
+        if not query_params:
+            return {}
+
+        prepared: Dict[str, Any] = {}
+        for key, value in query_params.items():
+            if value is None:
+                continue
+            if isinstance(value, bool):
+                prepared[key] = str(value).lower()
+            else:
+                prepared[key] = value
+
+        return prepared
 
     def _get_request_options(self, kwargs: Dict) -> Dict:
         """Extract request options from kwargs."""

--- a/src/evo_client/sync/core/request_handler.py
+++ b/src/evo_client/sync/core/request_handler.py
@@ -35,7 +35,7 @@ class SyncRequestHandler:
             headers.update(header_params)
         return headers
 
-    def _prepare_params(self, query_params: Optional[Dict] = None) -> Dict:
+    def _prepare_params(self, query_params: Optional[Dict] = None) -> Dict[str, Any]:
         """Prepare query parameters.
 
         Boolean values are converted to lowercase strings so that sync and async

--- a/test/aio/core/test_async_request_handler.py
+++ b/test/aio/core/test_async_request_handler.py
@@ -194,10 +194,10 @@ async def test_prepare_params():
     params = handler._prepare_params()
     assert params == {}
 
-    # Test with query_params
-    query_params = {"filter": "active", "limit": 10}
+    # Test with query_params including bool and None
+    query_params = {"filter": "active", "limit": 10, "flag": True, "skip": None}
     params = handler._prepare_params(query_params)
-    assert params == query_params
+    assert params == {"filter": "active", "limit": 10, "flag": "true"}
 
 
 @pytest.mark.asyncio

--- a/test/sync/core/test_sync_request_handler.py
+++ b/test/sync/core/test_sync_request_handler.py
@@ -60,10 +60,10 @@ def test_prepare_params(sync_request_handler):
     params = sync_request_handler._prepare_params()
     assert params == {}
 
-    # Test with query_params
-    query_params = {"filter": "active", "limit": 10}
+    # Test with query_params including bool and None
+    query_params = {"filter": "active", "limit": 10, "flag": True, "skip": None}
     params = sync_request_handler._prepare_params(query_params)
-    assert params == query_params
+    assert params == {"filter": "active", "limit": 10, "flag": "true"}
 
 
 def test_get_request_options(sync_request_handler):
@@ -77,7 +77,7 @@ def test_get_request_options(sync_request_handler):
     kwargs = {"timeout": 60, "verify": False}
     options = sync_request_handler._get_request_options(kwargs)
     assert options["request_timeout"] == 60
-    assert options["verify_ssl"] == False
+    assert not options["verify_ssl"]
 
 
 def test_make_request_success(sync_request_handler):


### PR DESCRIPTION
## Summary
- convert boolean query params to strings in request handlers
- update tests for new bool handling

## Testing
- `pre-commit run --files src/evo_client/aio/core/request_handler.py src/evo_client/sync/core/request_handler.py test/aio/core/test_async_request_handler.py test/sync/core/test_sync_request_handler.py test/aio/api/test_async_membership_api.py test/api/test_membership_api.py test/aio/api/test_async_workout_api.py`
- `pytest -q test/aio/core/test_async_request_handler.py test/sync/core/test_sync_request_handler.py test/aio/api/test_async_membership_api.py test/api/test_membership_api.py test/aio/api/test_async_workout_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6875955295f08323af627f96b5e5188a