### PR TITLE
fix: resolve ContratosResumoApiViewModel validation error with tuple input

### DIFF
--- a/src/evo_client/core/response.py
+++ b/src/evo_client/core/response.py
@@ -67,9 +67,24 @@ class RESTResponse(io.IOBase):
         origin = get_origin(response_type)
         if origin is list:
             item_type = get_args(response_type)[0]
-            return cast(
-                List[T], [item_type.model_validate(item) for item in self.json()]
-            )
+            json_data = self.json()
+            
+            # If the response is a single dictionary and we expect a list,
+            # wrap it in a list (this handles container responses)
+            if isinstance(json_data, dict):
+                return cast(List[T], [item_type.model_validate(json_data)])
+            
+            # If it's already a list, validate each item
+            elif isinstance(json_data, list):
+                return cast(
+                    List[T], [item_type.model_validate(item) for item in json_data]
+                )
+            
+            # Fallback: try to iterate over the response
+            else:
+                return cast(
+                    List[T], [item_type.model_validate(item) for item in json_data]
+                )
 
         # Direct construction for simple types
         return cast(Union[T, List[T]], response_type(**self.json()))


### PR DESCRIPTION
## Summary
Fixed a critical bug in API response deserialization that was causing validation errors in the MCP server when fetching membership data.

**Error being fixed:**
```
Failed to retrieve memberships: 1 validation error for ContratosResumoApiViewModel
Input should be a valid dictionary or instance of ContratosResumoApiViewModel
[type=model_type, input_value=('qtde', 13), input_type=tuple]
```

## Root Cause
The issue occurred when the API returned a single dictionary object (like `{"qtde": 13, "lista": [], "list": []}`) but the client expected a `List[ContratosResumoContainerViewModel]`. 

The old deserialization logic would:
1. Get the dictionary response 
2. Try to iterate over it with `for item in dict` 
3. This yields dictionary keys (`'qtde'`, `'lista'`, `'list'`) instead of values
4. Try to validate these keys as ContratosResumoApiViewModel objects, causing the tuple error

## Solution
Enhanced the response deserialization logic in both sync and async handlers to:
- Detect when API returns a single dictionary but we expect a list
- Properly wrap the dictionary in a list before validation
- Maintain backward compatibility with existing list responses
- Handle edge cases gracefully

## Files Changed
- `src/evo_client/core/response.py` - Fixed sync response deserialization
- `src/evo_client/aio/core/request_handler.py` - Fixed async response deserialization

## Test Plan
- [x] Created and ran isolated test to verify the fix handles both dictionary and list responses correctly
- [x] Confirmed old logic fails with tuple error as expected  
- [x] Confirmed new logic properly handles single container responses
- [x] Verified backward compatibility with list responses

🤖 Generated with [Claude Code](https://claude.ai/code)